### PR TITLE
Some refactoring to fix Linux support

### DIFF
--- a/pygeckodriver/__init__.py
+++ b/pygeckodriver/__init__.py
@@ -9,24 +9,21 @@ import platform
 
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 def _get_filename():
     path = os.path.join(_BASE_DIR, 'geckodriver_')
 
+    arch = '64' if platform.machine().endswith('64') else '32'
+
     sys = platform.system()
-    arch = platform.machine()
-    file_extension = None
     if sys == 'Darwin':
         path += 'macos'
+    elif sys == 'Windows':
+        path += 'win{}.exe'.format(arch)
+    elif sys == 'Linux':
+        path += 'linux{}'.format(arch)
     else:
-        if sys == 'Windows':
-            path += 'win'
-            file_extension = ".exe"
-        elif sys == 'Linux':
-            path += 'linux'
-        else:
-            raise Exception('OS not supported')
-        path += '64' if arch.endswith('64') else '32'
-        path += file_extension
+        raise Exception('OS {} not supported'.format(sys))
 
     if not os.path.exists(path):
         raise FileNotFoundError('GeckoDriver for {}({}) '

--- a/pygeckodriver/__init__.py
+++ b/pygeckodriver/__init__.py
@@ -11,20 +11,19 @@ _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _get_filename():
-    path = os.path.join(_BASE_DIR, 'geckodriver_')
-
     arch = '64' if platform.machine().endswith('64') else '32'
 
     sys = platform.system()
     if sys == 'Darwin':
-        path += 'macos'
+        file_name = 'geckodriver_macos'
     elif sys == 'Windows':
-        path += 'win{}.exe'.format(arch)
+        file_name = 'geckodriver_win{}.exe'.format(arch)
     elif sys == 'Linux':
-        path += 'linux{}'.format(arch)
+        file_name = 'geckodriver_linux{}'.format(arch)
     else:
         raise Exception('OS {} not supported'.format(sys))
 
+    path = os.path.join(_BASE_DIR, file_name)
     if not os.path.exists(path):
         raise FileNotFoundError('GeckoDriver for {}({}) '
                                 'is not found.'.format(sys, arch))

--- a/update.py
+++ b/update.py
@@ -85,7 +85,7 @@ def download_geckodriver(version):
                         or 'win64' in filename:
                     filename += '.exe'
 
-                if '.tar.gz' in asset['name']:
+                if asset['name'].endswith('.tar.gz'):
                     tf = tarfile.open(fileobj=BytesIO(requests.get(url).content))
                     for f in tf.getnames():
                         if 'geckodriver' in f:
@@ -93,7 +93,7 @@ def download_geckodriver(version):
                             os.rename(os.path.join(DOWNLOAD_DIR, f), \
                                     os.path.join(DOWNLOAD_DIR, filename))
                             os.chmod(os.path.join(DOWNLOAD_DIR, filename), 0o755)
-                elif '.gz' in asset['name']:
+                elif asset['name'].endswith('.gz'):
                     gf = gzip.GzipFile(fileobj=BytesIO(requests.get(url).content))
                     with open(os.path.join(DOWNLOAD_DIR, filename), 'wb') as f:
                         f.write(gf.read())


### PR DESCRIPTION
Hi!

I've tried to use this package with Linux Mint and faced with following exception.

```
Traceback (most recent call last):
  File "/home/valera/code/personal/project/main.py", line 1, in <module>
    from pygeckodriver import geckodriver_path
  File "/home/valera/code/personal/project/venv/lib/python3.8/site-packages/pygeckodriver/__init__.py", line 37, in <module>
    geckodriver_path = _get_filename()
  File "/home/valera/code/personal/project/venv/lib/python3.8/site-packages/pygeckodriver/__init__.py", line 29, in _get_filename
    path += file_extension
TypeError: can only concatenate str (not "NoneType") to str
```

So I've looked through source code and found a problem with `file_extension` variable. Minimal fix to make it work looks like
```
---      file_extension = None
+++      file_extension = ''
```
But I think some refactoring makes this code a bit more readable and error-proof.

Fixes #5 